### PR TITLE
Add configuration to choose between reverting to page one on sort or …

### DIFF
--- a/src/ColumnSortable/SortableLink.php
+++ b/src/ColumnSortable/SortableLink.php
@@ -252,7 +252,9 @@ class SortableLink
         };
 
         $columnExceptions = ['sort', 'direction'];
-        if (config('columnsortable.keep_page', false)) {
+        $keepPage = config('columnsortable.keep_page', false);
+
+        if ($keepPage === false) {
             $columnExceptions[] = 'page';
         }
 

--- a/src/ColumnSortable/SortableLink.php
+++ b/src/ColumnSortable/SortableLink.php
@@ -251,7 +251,12 @@ class SortableLink
             return is_array($element) ? $element : strlen($element);
         };
 
-        $persistParameters = array_filter(request()->except('sort', 'direction', 'page'), $checkStrlenOrArray);
+        $columnExceptions = ['sort', 'direction'];
+        if (config('columnsortable.keep_page', false)) {
+            $columnExceptions[] = 'page';
+        }
+
+        $persistParameters = array_filter(request()->except($columnExceptions), $checkStrlenOrArray);
         $queryString       = http_build_query(array_merge($queryParameters, $persistParameters, [
             'sort'      => $sortParameter,
             'direction' => $direction,
@@ -268,7 +273,7 @@ class SortableLink
         }
 
         unset($anchorAttributes['href']);
-        
+
         $attributes = [];
         foreach ($anchorAttributes as $k => $v) {
             $attributes[] = $k.('' != $v ? '="'.$v.'"' : '');

--- a/src/config/columnsortable.php
+++ b/src/config/columnsortable.php
@@ -118,4 +118,10 @@ return [
     for more information see https://github.com/Kyslik/column-sortable/issues/59
     */
     'join_type'                     => 'leftJoin',
+
+    /*
+    keep page: stay on the current page while sorting a column
+    default will return to the first page when sorting a column
+    */
+    'keep_page'                     => false,
 ];


### PR DESCRIPTION
…to stay on the current page

- Add keep_page configuration to columnsortable.php

- Add check in SortableLink.php buildQueryString method to add 'page' in the column exception list by the keep_page configuration